### PR TITLE
Added a depsDir option which allows for checking nested dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ Type: `string`
 
 Default: the closest directory containing `package.json` or `bower.json` (depending on `packageManager` specified) when going up the tree, starting from the current one
 
+### depsDir
+
+Path to the directory containing `node_modules` or `bower_components`.
+
+Type: `string`
+
+Default: `undefined`. By default, check-dependencies will use the `packageDir` option.
+
 ### onlySpecified
 
 Ensures all installed dependencies are specified in `package.json` or `bower.json`.

--- a/README.md
+++ b/README.md
@@ -125,6 +125,22 @@ Type: `boolean`
 
 Default: `false`
 
+### checkGitUrls
+
+By default, check-dependencies will skip version check for packages whose version contains the full repository path.  For example:
+
+```js
+    "dependencies": {
+      "semver": "https://github.com/npm/node-semver.git#0.5.9"
+    }
+```
+
+If checkGitUrls is enabled, check-dependencies will parse the version number (after the path to the git repository and the hash) and check it against the version of the installed package.
+
+Type: `boolean`
+
+Default: `false`
+
 ### verbose
 
 Prints messages to the console.

--- a/lib/check-dependencies.js
+++ b/lib/check-dependencies.js
@@ -101,7 +101,7 @@ function checkDependenciesHelper(syncOrAsync, config, callback) {
         pkgManagerPath = findup('node_modules/bower/bin/bower');
     }
 
-    depsDir = options.packageDir + '/' + depsDirName;
+    depsDir = (options.depsDir || options.packageDir) + '/' + depsDirName;
 
     // Make sure each package from `scopeList` is present and matches the specified version range.
     // Packages from `optionalScopeList` may not be present but if they are, they are required


### PR DESCRIPTION
I need the ability to check nested dependencies, e.g., a Bower package's dependencies that are critically important but aren't specified in my project's own `bower.json` file.

I added `depsDir` so I could create a configuration that read my dependency's `bower.json` file but checked my project's `bower_components` directory. If `depsDir` is falsey, `packageDir` is used instead (which is what is used now).

I also updated README to include a blurb about `depsDir` and another blurb about `checkGitUrls`, which I found very useful but was missing from the list of options.